### PR TITLE
Add optional support for forcing guitars on both PS2 and 360

### DIFF
--- a/_ark/(..)/(..)/system/run/config/joypad.dta
+++ b/_ark/(..)/(..)/system/run/config/joypad.dta
@@ -19,6 +19,12 @@
 #ifdef FORCE_GUITAR
 (controllers
    (ro_guitar
+      (detect))
+   (digital
+      (detect))
+   (analog
+      (detect))
+   (dualshock
       (detect)))
 #else
 (controllers
@@ -80,6 +86,14 @@
 #ifdef FORCE_GUITAR
 (controllers
    (ro_guitar_xbox
+      (detect))
+   #ifndef _SHIP
+   (ro_guitar_xbox_old
+      (detect))
+   (ro_guitar_xbox_old_2
+      (detect))
+   #endif
+   (analog
       (detect)))
 #else
 (controllers

--- a/_ark/(..)/(..)/system/run/config/joypad.dta
+++ b/_ark/(..)/(..)/system/run/config/joypad.dta
@@ -16,6 +16,11 @@
       (36 50))
    (come_first FALSE))
 #ifdef HX_EE
+#ifdef FORCE_GUITAR
+(controllers
+   (ro_guitar
+      (detect)))
+#else
 (controllers
    (ro_guitar
       (detect
@@ -30,6 +35,7 @@
    (dualshock
       (detect
          (type kJoypadDualShock))))
+#endif
 #endif
 #ifdef HX_PS3
 (controllers
@@ -71,6 +77,11 @@
       (bidirectional TRUE)))
 #endif
 #ifdef HX_XBOX
+#ifdef FORCE_GUITAR
+(controllers
+   (ro_guitar_xbox
+      (detect)))
+#else
 (controllers
    (ro_guitar_xbox
       (detect
@@ -90,6 +101,7 @@
       (detect
          (type kJoypadAnalog))
       (bidirectional TRUE)))
+#endif
 #endif
 (adapters
    (map

--- a/_ark/config/beatmatch_controller.dta
+++ b/_ark/config/beatmatch_controller.dta
@@ -1,3 +1,39 @@
+#ifdef FORCE_GUITAR
+(joypad_guitar
+   (slots kPad_L2 0 kPad_L1 1 kPad_R1 2 kPad_R2 3 kPad_X 4)
+   (force_mercury kPad_Select)
+   (dpad_for_navigation FALSE))
+(lefty_joypad_guitar
+   (slots kPad_X 0 kPad_R2 1 kPad_R1 2 kPad_L1 3 kPad_L2 4)
+   (force_mercury kPad_Select)
+   (dpad_for_navigation FALSE))
+(guitar
+   (slots kPad_R2 0 kPad_Circle 1 kPad_Tri 2 kPad_X 3 kPad_Square 4)
+   (force_mercury kPad_Select))
+#ifdef HX_EE
+(joypad
+   (slots kPad_R2 0 kPad_Circle 1 kPad_Tri 2 kPad_X 3 kPad_Square 4)
+   (force_mercury kPad_Select))
+(guitar_xbox
+   (slots kPad_X 0 kPad_Tri 1 kPad_Square 2 kPad_Circle 3 kPad_L1 4)
+   (force_mercury kPad_Select)
+   (mercury_switch kPad_RStickUp))
+#endif
+#ifdef HX_XBOX
+(joypad
+   (slots kPad_X 0 kPad_Tri 1 kPad_Circle 2 kPad_Square 3 kPad_L1 4)
+   (controller_style ro_xbox)
+   (force_mercury kPad_Select))
+(hx_guitar_xbox
+   (slots kPad_X 0 kPad_Tri 1 kPad_Square 2 kPad_Circle 3 kPad_L1 4)
+   (controller_style ro_xbox)
+   (force_mercury kPad_Select))
+(hx_guitar_xbox_new
+   (slots kPad_X 0 kPad_Tri 1 kPad_Circle 2 kPad_Square 3 kPad_L1 4)
+   (controller_style ro_xbox)
+   (force_mercury kPad_Select))
+#endif
+#else
 (joypad
    (slots kPad_L2 0 kPad_L1 1 kPad_R1 2 kPad_R2 3 kPad_X 4)
    (force_mercury kPad_Select)
@@ -28,4 +64,5 @@
    (slots kPad_X 0 kPad_Tri 1 kPad_Circle 2 kPad_Square 3 kPad_L1 4)
    (controller_style ro_xbox)
    (force_mercury kPad_Select))
+#endif
 #endif

--- a/_ark/config/macros.dta
+++ b/_ark/config/macros.dta
@@ -1,3 +1,6 @@
+; In order to force all controllers to be guitar controllers, uncomment the line below.
+;#define FORCE_GUITAR (1)
+
 #ifdef APP_MACROS_DTA
 #else
 #define APP_MACROS_DTA


### PR DESCRIPTION
In order to activate, uncomment the line in `config/macros`.

Only tested on Xenia using a Santroller controller on Linux, but should also work on PS2 and a real 360. Unlike the previous patch for PS2, this patch remaps the buttons to the buttons that a guitar controller would use on the respective consoles.

Credit to @jnackmclain for the previous patch and for giving me some pointers, available here: https://github.com/Milohax-archive/Guitar-Hero-II-Deluxe/commit/1832d638adeb9f2775ec7efd1939ad542b49cb36